### PR TITLE
Fix #27 - index order

### DIFF
--- a/app/controllers/exception_hunter/errors_controller.rb
+++ b/app/controllers/exception_hunter/errors_controller.rb
@@ -5,7 +5,7 @@ module ExceptionHunter
     include Pagy::Backend
 
     def index
-      @errors = ErrorGroup.all.order(created_at: :desc)
+      @errors = ErrorGroup.all.order(updated_at: :desc)
       @errors_count = Error.count
       @month_errors = Error.in_current_month.count
     end

--- a/app/models/exception_hunter/error.rb
+++ b/app/models/exception_hunter/error.rb
@@ -6,6 +6,7 @@ module ExceptionHunter
     belongs_to :error_group
 
     before_validation :set_occurred_at, on: :create
+    after_create :update_error_group
 
     scope :most_recent, lambda { |error_group_id|
       where(error_group_id: error_group_id).order(occurred_at: :desc)
@@ -21,6 +22,10 @@ module ExceptionHunter
 
     def set_occurred_at
       self.occurred_at ||= Time.now
+    end
+
+    def update_error_group
+      error_group.touch
     end
   end
 end

--- a/app/models/exception_hunter/error.rb
+++ b/app/models/exception_hunter/error.rb
@@ -3,10 +3,9 @@ module ExceptionHunter
     validates :class_name, presence: true
     validates :occurred_at, presence: true
 
-    belongs_to :error_group
+    belongs_to :error_group, touch: true
 
     before_validation :set_occurred_at, on: :create
-    after_create :update_error_group
 
     scope :most_recent, lambda { |error_group_id|
       where(error_group_id: error_group_id).order(occurred_at: :desc)
@@ -22,10 +21,6 @@ module ExceptionHunter
 
     def set_occurred_at
       self.occurred_at ||= Time.now
-    end
-
-    def update_error_group
-      error_group.touch
     end
   end
 end

--- a/spec/models/exception_hunter/error_spec.rb
+++ b/spec/models/exception_hunter/error_spec.rb
@@ -12,6 +12,15 @@ module ExceptionHunter
       it { is_expected.to belong_to(:error_group) }
     end
 
+    describe 'on creation' do
+      let(:error_group) { create(:error_group) }
+      let(:error) { build(:error, error_group: error_group) }
+
+      it 'touches error group' do
+        expect { error.save }.to change { error_group.reload.updated_at }
+      end
+    end
+
     describe 'occurred at' do
       let!(:error) { create(:error, occurred_at: nil) }
 


### PR DESCRIPTION
fix index order by attr `updated_at` on error group instead of `created_at`
now errors update `updated_at` on their error group after being created

fix #27 