### PR TITLE
Fix errors not being distinct

### DIFF
--- a/app/controllers/exception_hunter/errors_controller.rb
+++ b/app/controllers/exception_hunter/errors_controller.rb
@@ -6,7 +6,8 @@ module ExceptionHunter
 
     def index
       @dashboard = DashboardPresenter.new(current_tab)
-      @errors = ErrorGroupPresenter.wrap_collection(errors_for_tab(@dashboard).order(updated_at: :desc))
+      shown_errors = errors_for_tab(@dashboard).order(updated_at: :desc).distinct
+      @errors = ErrorGroupPresenter.wrap_collection(shown_errors)
     end
 
     def show


### PR DESCRIPTION
Fixes the same error groups appearing multiple times in the dashboard introduced in #57 

![image](https://user-images.githubusercontent.com/17035407/83438559-00559300-a418-11ea-9e8e-77a26f1698b8.png)
 