### PR TITLE
Fix ErrorPresenter failing when the error does not have environment data

### DIFF
--- a/app/presenters/exception_hunter/error_presenter.rb
+++ b/app/presenters/exception_hunter/error_presenter.rb
@@ -16,7 +16,7 @@ module ExceptionHunter
     end
 
     def environment_data
-      error.environment_data.except('params')
+      error.environment_data&.except('params') || {}
     end
 
     def tracked_params

--- a/spec/presenters/exception_hunter/error_presenter_spec.rb
+++ b/spec/presenters/exception_hunter/error_presenter_spec.rb
@@ -6,19 +6,30 @@ module ExceptionHunter
 
     describe '#environment_data' do
       subject { error_presenter.environment_data }
-      let(:error) do
-        create(:error,
-               environment_data: {
-                 'something' => 123,
-                 'something_else' => 'abcd',
-                 'params' => {
-                   'name' => 'John'
-                 }
-               })
+
+      context 'when the error has environment data' do
+        let(:error) do
+          create(:error,
+                 environment_data: {
+                   'something' => 123,
+                   'something_else' => 'abcd',
+                   'params' => {
+                     'name' => 'John'
+                   }
+                 })
+        end
+
+        it 'returns the error environment data without the params' do
+          expect(subject).to eq({ 'something' => 123, 'something_else' => 'abcd' })
+        end
       end
 
-      it 'returns the error environment data without the params' do
-        expect(subject).to eq({ 'something' => 123, 'something_else' => 'abcd' })
+      context 'when the error does not have environment data' do
+        let(:error) { create(:error, environment_data: nil) }
+
+        it 'returns an empty hash' do
+          expect(subject).to eq({})
+        end
       end
     end
 


### PR DESCRIPTION
**Bug**: Whenever there's an error without environment data, the `ErrorPresenter` fails, resulting in the view not being able to render the error summary.

![image](https://user-images.githubusercontent.com/7276679/89682509-39edc300-d8cd-11ea-8dad-b9c72a2dbbf0.png)

**Solution**: Just place a safe navigation operator and return `{}` if the environment data is missing