### PR TITLE
Fix various bugs

### DIFF
--- a/app/models/exception_hunter/error.rb
+++ b/app/models/exception_hunter/error.rb
@@ -1,5 +1,5 @@
 module ExceptionHunter
-  class Error < ApplicationRecord
+  class Error < ::ExceptionHunter::ApplicationRecord
     validates :class_name, presence: true
     validates :occurred_at, presence: true
 

--- a/app/models/exception_hunter/error_group.rb
+++ b/app/models/exception_hunter/error_group.rb
@@ -1,5 +1,5 @@
 module ExceptionHunter
-  class ErrorGroup < ApplicationRecord
+  class ErrorGroup < ::ExceptionHunter::ApplicationRecord
     SIMILARITY_THRESHOLD = 0.75
 
     validates :error_class_name, presence: true

--- a/app/presenters/exception_hunter/error_presenter.rb
+++ b/app/presenters/exception_hunter/error_presenter.rb
@@ -10,7 +10,7 @@ module ExceptionHunter
     end
 
     def backtrace
-      error.backtrace.map do |line|
+      (error.backtrace || []).map do |line|
         format_backtrace_line(line)
       end
     end

--- a/lib/exception_hunter/error_creator.rb
+++ b/lib/exception_hunter/error_creator.rb
@@ -10,8 +10,8 @@ module ExceptionHunter
 
         ActiveRecord::Base.transaction do
           error_attrs = extract_user_data(error_attrs)
-          error = Error.new(error_attrs)
-          error_group = ErrorGroup.find_matching_group(error) || ErrorGroup.new
+          error = ::ExceptionHunter::Error.new(error_attrs)
+          error_group = ::ExceptionHunter::ErrorGroup.find_matching_group(error) || ::ExceptionHunter::ErrorGroup.new
           update_error_group(error_group, error, tag)
           error.error_group = error_group
           error.save!

--- a/lib/exception_hunter/tracking.rb
+++ b/lib/exception_hunter/tracking.rb
@@ -7,7 +7,8 @@ module ExceptionHunter
         message: exception.message,
         backtrace: exception.backtrace,
         custom_data: custom_data,
-        user: user
+        user: user,
+        environment_data: {}
       )
 
       nil


### PR DESCRIPTION
### Summary

- There was a bug where the environment data was not being set for manually tracked errors.
- There was a bug where namespacing was not being resolved correctly. As an example:

```ruby
module ExceptionHunter
  class ErrorCreator
    def create
      # ..
      Error.something # Raises an undefined constant error
    end
  end
end
```

