### PR TITLE
show project name instead of repo name on navbar

### DIFF
--- a/app/views/layouts/exception_hunter/application.html.erb
+++ b/app/views/layouts/exception_hunter/application.html.erb
@@ -24,7 +24,9 @@
       <div class="row">
         <div class="column column-40">
           <%= link_to errors_path do %>
-            <div class="nav__title"><%= Rails.application.class.module_parent_name %></div>
+            <div class="nav__title">
+              Exception Hunter / <%= Rails.application.class.module_parent_name %>
+            </div>
           <% end %>
         </div>
         <div class="column column-10 column-offset-50">

--- a/app/views/layouts/exception_hunter/application.html.erb
+++ b/app/views/layouts/exception_hunter/application.html.erb
@@ -24,7 +24,7 @@
       <div class="row">
         <div class="column column-40">
           <%= link_to errors_path do %>
-            <div class="nav__title">Exception Hunter</div>
+            <div class="nav__title"><%= Rails.application.class.module_parent_name %></div>
           <% end %>
         </div>
         <div class="column column-10 column-offset-50">


### PR DESCRIPTION
### Summary

Show project name on navbar

Closes #56 

### Other Information

<img width="1171" alt="Screen Shot 2020-10-01 at 21 59 57" src="https://user-images.githubusercontent.com/24760990/94826494-8f5bd180-0431-11eb-81ce-6a426b0a8fab.png">

