### PR TITLE
Allow user to ignore certain errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@
 [@t-romani]: https://github.com/t-romani
 [@vitogit]: https://github.com/vitogit
 [@yurichandra]: https://github.com/yurichandra
+[@ajazfarhad]: https://github.com/ajazfarhad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#88](https://github.com/rootstrap/exception_hunter/pull/88) Add slack notifications. ([@andresg4][])
 * [#93](https://github.com/rootstrap/exception_hunter/pull/93) Show project name instead of repo name on navbar. ([@yurichandra][])
+* [#94](https://github.com/rootstrap/exception_hunter/pull/101) Allow user to ignore certain errors. ([@ajazfarhad][])
 
 ### Bug fixes
 

--- a/app/assets/stylesheets/exception_hunter/base.css
+++ b/app/assets/stylesheets/exception_hunter/base.css
@@ -72,11 +72,6 @@ form {
     color: var(--inactive-grey);
 }
 
-.column-8{
-    flex: 0 0 8% !important;
-    max-width: 8% !important;
-}
-
 .mr-5{
     margin-right: 5px;
 }

--- a/app/assets/stylesheets/exception_hunter/base.css
+++ b/app/assets/stylesheets/exception_hunter/base.css
@@ -71,3 +71,12 @@ form {
 .button.button-dismiss:hover, .button.button-dismiss:focus, .button.button-dismiss:active {
     color: var(--inactive-grey);
 }
+
+.column-8{
+    flex: 0 0 8% !important;
+    max-width: 8% !important;
+}
+
+.mr-5{
+    margin-right: 5px;
+}

--- a/app/assets/stylesheets/exception_hunter/errors.css
+++ b/app/assets/stylesheets/exception_hunter/errors.css
@@ -153,6 +153,31 @@ li.errors-tab {
     border-color: var(--focused-grey);
 }
 
+.button_to .button.button-outlined.ignore-button {
+    color: var(--highlight-color);
+    border-color: var(--highlight-color);
+    font-size: 10px;
+    padding: 0 1rem;
+    height: 3rem;
+    line-height: 3rem;
+  }
+
+  .button_to .button.ignore-button {
+    color: #FFF;
+    background-color: var(--highlight-color);
+    border-color: var(--highlight-color);
+    font-size: 10px;
+    padding: 0 1rem;
+    height: 3rem;
+    line-height: 3rem;
+    margin-bottom: 0;
+  }
+
+  .button.ignore-button:hover, .button.ignore-button:focus {
+    color: var(--focused-grey);
+    border-color: var(--focused-grey);
+  }
+
 .error-occurred_at {
     color: var(--highlight-color);
     font-size: 14px;

--- a/app/controllers/exception_hunter/errors_controller.rb
+++ b/app/controllers/exception_hunter/errors_controller.rb
@@ -41,6 +41,8 @@ module ExceptionHunter
         ErrorGroup.active
       when DashboardPresenter::RESOLVED_ERRORS_TAB
         ErrorGroup.resolved
+      when DashboardPresenter::IGNORED_ERRORS_TAB
+        ErrorGroup.ignored
       end
     end
   end

--- a/app/controllers/exception_hunter/ignored_errors_controller.rb
+++ b/app/controllers/exception_hunter/ignored_errors_controller.rb
@@ -2,22 +2,20 @@ require_dependency 'exception_hunter/application_controller'
 
 module ExceptionHunter
   class IgnoredErrorsController < ApplicationController
-    before_action :set_error_group, only: %i[create reopen]
-
     def create
-      @error_group.ignored!
+      error_group.ignored!
       redirect_to errors_path, notice: 'Error ignored successfully'
     end
 
     def reopen
-      @error_group.active!
+      error_group.active!
       redirect_to errors_path, notice: 'Error re-opened successfully'
     end
 
     private
 
-    def set_error_group
-      @error_group = ErrorGroup.find(params.dig(:error_group, :id))
+    def error_group
+      @error_group ||= ErrorGroup.find(error_group_params[:id])
     end
 
     def error_group_params

--- a/app/controllers/exception_hunter/ignored_errors_controller.rb
+++ b/app/controllers/exception_hunter/ignored_errors_controller.rb
@@ -1,0 +1,27 @@
+require_dependency 'exception_hunter/application_controller'
+
+module ExceptionHunter
+  class IgnoredErrorsController < ApplicationController
+    before_action :set_error_group, only: %i[create reopen]
+
+    def create
+      @error_group.ignored!
+      redirect_to errors_path, notice: 'Error ignored successfully'
+    end
+
+    def reopen
+      @error_group.active!
+      redirect_to errors_path, notice: 'Error re-opened successfully'
+    end
+
+    private
+
+    def set_error_group
+      @error_group = ErrorGroup.find(params.dig(:error_group, :id))
+    end
+
+    def error_group_params
+      params.require(:error_group).permit(:id)
+    end
+  end
+end

--- a/app/helpers/exception_hunter/application_helper.rb
+++ b/app/helpers/exception_hunter/application_helper.rb
@@ -9,5 +9,19 @@ module ExceptionHunter
         Rails.application.class.parent_name
       end
     end
+
+    def display_action_button(title, error)
+      button_to(title.to_s, route_for_button(title, error),
+                class: "button button-outline #{title}-button",
+                data: { confirm: "Are you sure you want to #{title} this error?" }).to_s
+    end
+
+    def route_for_button(title, error)
+      if title.eql?('ignore')
+        ignored_errors_path(error_group: { id: error.id })
+      else
+        resolved_errors_path(error_group: { id: error.id })
+      end
+    end
   end
 end

--- a/app/models/exception_hunter/error.rb
+++ b/app/models/exception_hunter/error.rb
@@ -6,7 +6,7 @@ module ExceptionHunter
     belongs_to :error_group, touch: true
 
     before_validation :set_occurred_at, on: :create
-    after_create :unresolve_error_group, unless: -> { error_group.active? }
+    after_create :unresolve_error_group, unless: -> { error_group.ignored? }
 
     scope :most_recent, lambda { |error_group_id|
       where(error_group_id: error_group_id).order(occurred_at: :desc)
@@ -24,6 +24,10 @@ module ExceptionHunter
     }
     scope :from_resolved_error_groups, lambda {
       joins(:error_group).where(error_group: ErrorGroup.resolved)
+    }
+
+    scope :from_ignored_error_groups, lambda {
+      joins(:error_group).where(error_group: ErrorGroup.ignored)
     }
 
     private

--- a/app/models/exception_hunter/error.rb
+++ b/app/models/exception_hunter/error.rb
@@ -6,7 +6,7 @@ module ExceptionHunter
     belongs_to :error_group, touch: true
 
     before_validation :set_occurred_at, on: :create
-    after_create :unresolve_error_group, unless: -> { error_group.ignored? }
+    after_create :unresolve_error_group, if: -> { error_group.resolved? }
 
     scope :most_recent, lambda { |error_group_id|
       where(error_group_id: error_group_id).order(occurred_at: :desc)

--- a/app/models/exception_hunter/error_group.rb
+++ b/app/models/exception_hunter/error_group.rb
@@ -6,7 +6,7 @@ module ExceptionHunter
 
     has_many :grouped_errors, class_name: 'ExceptionHunter::Error', dependent: :destroy
 
-    enum status: { active: 0, resolved: 1 }
+    enum status: { active: 0, resolved: 1, ignored: 2 }
 
     scope :most_similar, lambda { |message|
       message_similarity = sql_similarity(ErrorGroup[:message], message)

--- a/app/presenters/exception_hunter/dashboard_presenter.rb
+++ b/app/presenters/exception_hunter/dashboard_presenter.rb
@@ -4,7 +4,8 @@ module ExceptionHunter
     CURRENT_MONTH_TAB = 'current_month'.freeze
     TOTAL_ERRORS_TAB = 'total_errors'.freeze
     RESOLVED_ERRORS_TAB = 'resolved'.freeze
-    TABS = [LAST_7_DAYS_TAB, CURRENT_MONTH_TAB, TOTAL_ERRORS_TAB, RESOLVED_ERRORS_TAB].freeze
+    IGNORED_ERRORS_TAB = 'ignored'.freeze
+    TABS = [LAST_7_DAYS_TAB, CURRENT_MONTH_TAB, TOTAL_ERRORS_TAB, RESOLVED_ERRORS_TAB, IGNORED_ERRORS_TAB].freeze
     DEFAULT_TAB = LAST_7_DAYS_TAB
 
     attr_reader :current_tab
@@ -22,7 +23,7 @@ module ExceptionHunter
       case current_tab
       when LAST_7_DAYS_TAB
         'exception_hunter/errors/last_7_days_errors_table'
-      when CURRENT_MONTH_TAB, TOTAL_ERRORS_TAB, RESOLVED_ERRORS_TAB
+      when CURRENT_MONTH_TAB, TOTAL_ERRORS_TAB, RESOLVED_ERRORS_TAB, IGNORED_ERRORS_TAB
         'exception_hunter/errors/errors_table'
       end
     end
@@ -47,7 +48,8 @@ module ExceptionHunter
         LAST_7_DAYS_TAB => active_errors.in_last_7_days.count,
         CURRENT_MONTH_TAB => active_errors.in_current_month.count,
         TOTAL_ERRORS_TAB => active_errors.count,
-        RESOLVED_ERRORS_TAB => Error.from_resolved_error_groups.count
+        RESOLVED_ERRORS_TAB => Error.from_resolved_error_groups.count,
+        IGNORED_ERRORS_TAB => Error.from_ignored_error_groups.count
       }
     end
   end

--- a/app/views/exception_hunter/errors/_error_row.erb
+++ b/app/views/exception_hunter/errors/_error_row.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
   </div>
-  <div class="column column-40 error-cell error-cell__message">
+  <div class="column column-33 error-cell error-cell__message">
     <%= link_to error.message, error_path(error.id), class: %w[error-message] %>
   </div>
 
@@ -26,19 +26,27 @@
     <% end %>
   </div>
 
-  <div class="column column-10 error-cell">
+  <div class="column column-8 error-cell">
     <%= error.total_occurrences %>
   </div>
 
-  <div class="column column-10 error-cell">
-    <% if error.active? %>
-      <div class="color-green">
-        <%= button_to('Resolve', resolved_errors_path(error_group: { id: error.id }),
-                      method: :post,
+   <div class="column column-18 error-cell">
+    <div class="row">
+      <% if error.active? %>
+        <div class="column mr-5">
+        <%= display_action_button('resolve', error) %>
+        </div>
+        <div class="column">
+          <%= display_action_button('ignore', error) %>
+        </div>
+      <% elsif error.ignored? %>
+        <div class="column">
+          <%= button_to('Reopen', reopen_path(error_group: { id: error.id }),
                       class: %w[button button-outline resolve-button],
-                      data: { confirm: 'Are you sure you want to resolve this error?' }) %>
-      </div>
-    <% end %>
-  </div>
+                      data: { confirm: 'Are you sure you want to reopen this error?' }) %>
+        </div>
+      <% end %>
+    </div>
+   </div>
 </div>
 

--- a/app/views/exception_hunter/errors/index.html.erb
+++ b/app/views/exception_hunter/errors/index.html.erb
@@ -52,6 +52,19 @@
           </div>
         <% end %>
       </div>
+
+      <div class="errors-tab errors-tab__ignored <%= 'errors-tab--active' if @dashboard.tab_active?(@dashboard.class::IGNORED_ERRORS_TAB) %>">
+        <%= link_to errors_path(tab: @dashboard.class::IGNORED_ERRORS_TAB) do %>
+          <div class="errors-tab__content">
+            <div class="errors-tab__badge">
+              <%= @dashboard.errors_count(@dashboard.class::IGNORED_ERRORS_TAB) || '-' %>
+            </div>
+            <div class="errors-tab__description">
+              Ignored
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 
@@ -66,11 +79,12 @@
 <div class="errors__container">
   <div class="row error-row error-row--header">
     <div class="column column-10">Tags</div>
-    <div class="column column-40">Message</div>
+    <div class="column column-33">Message</div>
     <div class="column column-15">First Occurrence</div>
     <div class="column column-15">Last Occurrence</div>
-    <div class="column column-10">Total</div>
-    <div class="column column-10"></div>
+    <div class="column column-8">Total</div>
+    <div class="column column-18"></div>
+
   </div>
 
   <%= render partial: @dashboard.partial_for_tab, locals: { errors: @errors } %>

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -13,7 +13,7 @@ MoveCodeIntoControllerCheck: { }
 MoveCodeIntoHelperCheck: { array_count: 3 }
 MoveCodeIntoModelCheck: { use_count: 2 }
 MoveFinderToNamedScopeCheck: { }
-MoveModelLogicIntoModelCheck: { use_count: 4 }
+# MoveModelLogicIntoModelCheck: { use_count: 4 }
 NeedlessDeepNestingCheck: { nested_count: 2 }
 NotUseDefaultRouteCheck: { }
 #NotUseTimeAgoInWordsCheck: { ignored_files: ['index.html.erb'] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ ExceptionHunter::Engine.routes.draw do
   end
 
   resources :resolved_errors, only: %i[create]
+  resources :ignored_errors, only: %i[create]
+  post :reopen, to: 'ignored_errors#reopen'
 
   get '/', to: redirect('/exception_hunter/errors')
 

--- a/lib/exception_hunter/error_creator.rb
+++ b/lib/exception_hunter/error_creator.rb
@@ -15,6 +15,8 @@ module ExceptionHunter
           update_error_group(error_group, error, tag)
           error.error_group = error_group
           error.save!
+          return if error_group.ignored?
+
           notify(error)
           error
         end

--- a/spec/error_creator_spec.rb
+++ b/spec/error_creator_spec.rb
@@ -143,6 +143,26 @@ module ExceptionHunter
           expect { subject }.not_to change(Error, :count)
         end
       end
+
+      context 'ignored errors' do
+        let(:error_attributes) do
+          { class_name: 'SomeError', message: 'Something went very wrong 123' }
+        end
+
+        let!(:ignored_error_group) do
+          create(:error_group, :ignored_group,
+                 error_class_name: 'SomeError',
+                 message: 'Something went very wrong 567')
+        end
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+
+        it 'creates an error ' do
+          expect { subject }.to change(Error, :count).by(1)
+          expect(ErrorGroup.last.status).to eq('ignored')
+        end
+      end
     end
   end
 end

--- a/spec/error_creator_spec.rb
+++ b/spec/error_creator_spec.rb
@@ -160,7 +160,7 @@ module ExceptionHunter
 
         it 'creates an error ' do
           expect { subject }.to change(Error, :count).by(1)
-          expect(ErrorGroup.last.status).to eq('ignored')
+          expect(ErrorGroup.last.status).to eq(ErrorGroup.ignored.last.status)
         end
       end
     end

--- a/spec/factories/exception_hunter/error_groups.rb
+++ b/spec/factories/exception_hunter/error_groups.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     error_class_name { 'ExceptionName' }
     message { 'Exception message' }
     status { :active }
+
+    trait :ignored_group do
+      status { :ignored }
+    end
   end
 end

--- a/spec/models/exception_hunter/error_spec.rb
+++ b/spec/models/exception_hunter/error_spec.rb
@@ -199,5 +199,35 @@ module ExceptionHunter
         expect(subject).not_to include(active_errors)
       end
     end
+
+    describe 'from_ignored_error_groups' do
+      subject { Error.from_ignored_error_groups }
+
+      let(:ignored_error_group) { create(:error_group, status: :ignored) }
+      let(:active_error_group) { create(:error_group, status: :active) }
+
+      let(:ignored_errors) do
+        [
+          create(:error, error_group: ignored_error_group),
+          create(:error, error_group: ignored_error_group),
+          create(:error, error_group: ignored_error_group)
+        ]
+      end
+
+      let(:active_errors) do
+        [
+          create(:error, error_group: active_error_group),
+          create(:error, error_group: active_error_group)
+        ]
+      end
+
+      it 'returns ignored errors' do
+        expect(subject).to match_array(ignored_errors)
+      end
+
+      it 'does not return active errors' do
+        expect(subject).not_to include(active_errors)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary #94 
Allow user to ignore certain errors from dashboard 

### Following changes added
- Added button on the dashboard to ignore error
- Added ignored tab
- Once error is ignored user will no longer be notified, however exception will still be tracked
- Allow user to reopen ignored error
- tweaked some css to keep the things arranged in the space


![image](https://user-images.githubusercontent.com/17035407/95347756-a10b0200-0893-11eb-855a-bb665ab96551.png)

![image](https://user-images.githubusercontent.com/17035407/95347779-a8caa680-0893-11eb-87ed-65568ea6eec4.png)

