### PR TITLE
Exclude code analysis task from build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+* [#107](https://github.com/rootstrap/exception_hunter/pull/107) Excluded code_analysis task from the build. ([@andresg4][])
+
 ### Changes
 
 ## 1.0.0 (2020-11-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ### Bug fixes
 
-* [#107](https://github.com/rootstrap/exception_hunter/pull/107) Excluded code_analysis task from the build. ([@andresg4][])
-
 ### Changes
+
+* [#107](https://github.com/rootstrap/exception_hunter/pull/107) Excluded code_analysis task from the build. ([@andresg4][])
 
 ## 1.0.0 (2020-11-05)
 

--- a/exception_hunter.gemspec
+++ b/exception_hunter.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.5'
 
-  spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
+  EXCLUDED_FILES = %w[lib/tasks/code_analysis.rake].freeze
+  spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md'] - EXCLUDED_FILES
 
   spec.add_dependency 'pagy', '~> 3'
   spec.add_dependency 'slack-notifier', '~> 2.3'


### PR DESCRIPTION
### Summary

The `code_analysis` task was being included in the gem build. So when running the `code_analysis` task from the project the gem task also runs.
Now the `code_analysis` is excluded from the build.