### PR TITLE
Fix: purge errors task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+* [#110](https://github.com/rootstrap/exception_hunter/pull/110) Fix: purge errors task. (
+[@martinjaimem][])
 ### Changes
 
 ## 1.0.1 (2020-12-18)

--- a/lib/tasks/exception_hunter_tasks.rake
+++ b/lib/tasks/exception_hunter_tasks.rake
@@ -1,6 +1,6 @@
 namespace :exception_hunter do
   desc 'Purges old errors'
   task purge_errors: [:environment] do
-    ::ExceptionHunter::ErrorReaper.call
+    ::ExceptionHunter::ErrorReaper.purge
   end
 end

--- a/spec/tasks/purge_errors_spec.rb
+++ b/spec/tasks/purge_errors_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+Rails.application.load_tasks
+
+describe 'exception_hunter:purge_errors' do
+  it 'calls the ErrorReaper purge method' do
+    expect(::ExceptionHunter::ErrorReaper).to receive(:purge)
+
+    Rake::Task['exception_hunter:purge_errors'].invoke
+  end
+end


### PR DESCRIPTION
### Summary
This PR fixes the `rake` task that purges all errors which was pointing to the old `::ExceptionHunter::ErrorReaper.call` method instead of the new one `::ExceptionHunter::ErrorReaper.purge`