### PR TITLE
Send notifications with delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 * [#110](https://github.com/rootstrap/exception_hunter/pull/110) Fix: purge errors task. (
 [@martinjaimem][])
+* [#111](https://github.com/rootstrap/exception_hunter/pull/111) Send notifications with delay. (
+[@martinjaimem][])
+
 ### Changes
 
 ## 1.0.1 (2020-12-18)

--- a/lib/exception_hunter/error_creator.rb
+++ b/lib/exception_hunter/error_creator.rb
@@ -4,6 +4,7 @@ module ExceptionHunter
     HTTP_TAG = 'HTTP'.freeze
     WORKER_TAG = 'Worker'.freeze
     MANUAL_TAG = 'Manual'.freeze
+    NOTIFICATION_DELAY = 1.minute
 
     class << self
       # Creates an error with the given attributes and persists it to
@@ -59,7 +60,9 @@ module ExceptionHunter
           slack_notifier = ExceptionHunter::Notifiers::SlackNotifier.new(error, notifier)
           serializer = ExceptionHunter::Notifiers::SlackNotifierSerializer
           serialized_slack_notifier = serializer.serialize(slack_notifier)
-          ExceptionHunter::SendNotificationJob.perform_later(serialized_slack_notifier)
+          ExceptionHunter::SendNotificationJob.set(
+            wait: NOTIFICATION_DELAY
+          ).perform_later(serialized_slack_notifier)
         end
       end
 

--- a/spec/error_creator_spec.rb
+++ b/spec/error_creator_spec.rb
@@ -114,6 +114,15 @@ module ExceptionHunter
 
               expect(jobs).to contain_exactly('test_webhook_1', 'test_webhook_2')
             end
+
+            it 'enqueues job to send slack message to all webhooks with a delay between 50 and 70 seconds' do
+              one_minute_from_now = Time.now.to_i + 1.minute
+              subject
+
+              ActiveJob::Base.queue_adapter.enqueued_jobs.each do |job|
+                expect(job[:at]).to be_within(10.seconds).of(one_minute_from_now)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
### Summary

When performing the notification before saving the error there is an error raised that keeps being enqueued. This PR fixes it by adding a delay to it.


