### PR TITLE
Fix Github actions running multiple times

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,6 +1,6 @@
 name: Rails tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
### Summary

Github actions should only run on every action of a pull request, not on push.
