### PR TITLE
Refactor code duplication on errors for last week partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [#115](https://github.com/rootstrap/exception_hunter/pull/115) Fix Github actions running multiple times. ([@brunvez][])
 - [#116](https://github.com/rootstrap/exception_hunter/pull/116) Fix documentation link on the README. ([@brunvez][])
 - [#117](https://github.com/rootstrap/exception_hunter/pull/117) Fix specification on example for Manual tracking on the README ([@lalopsb][])
-
+- [#118](https://github.com/rootstrap/exception_hunter/pull/118) Refactor code duplication on errors for last week partial ([@lalopsb][])
 ## 1.0.2 (2020-02-03)
 
 ### Bug fixes

--- a/app/presenters/exception_hunter/error_group_presenter.rb
+++ b/app/presenters/exception_hunter/error_group_presenter.rb
@@ -11,7 +11,8 @@ module ExceptionHunter
     end
 
     def self.format_occurrence_day(day)
-      day.to_date.strftime('%A, %B %d')
+      date = day.to_date
+      date == Date.yesterday ? 'Yesterday' : date.strftime('%A, %B %d')
     end
 
     def show_for_day?(day)

--- a/app/views/exception_hunter/errors/_last_7_days_errors_table.erb
+++ b/app/views/exception_hunter/errors/_last_7_days_errors_table.erb
@@ -1,11 +1,7 @@
 <% today_errors = errors.select { |error| error.show_for_day?(Date.current) } %>
 <%= render partial: 'exception_hunter/errors/error_row', collection: today_errors, as: :error %>
 
-<% yesterday_errors = errors.select { |error| error.show_for_day?(Date.yesterday) } %>
-<div class="errors-date-group">Yesterday</div>
-<%= render partial: 'exception_hunter/errors/error_row', collection: yesterday_errors, as: :error %>
-
-<% (2..6).each do |i| %>
+<% (1..6).each do |i| %>
   <% errors_on_day = errors.select { |error| error.show_for_day?(i.days.ago) } %>
   <div class="errors-date-group"><%= ExceptionHunter::ErrorGroupPresenter.format_occurrence_day(i.days.ago) %></div>
   <%= render partial: 'exception_hunter/errors/error_row', collection: errors_on_day, as: :error %>

--- a/spec/presenters/exception_hunter/error_group_presenter_spec.rb
+++ b/spec/presenters/exception_hunter/error_group_presenter_spec.rb
@@ -14,6 +14,14 @@ module ExceptionHunter
       it 'returns the last occurrence date formatted as a string' do
         expect(ErrorGroupPresenter.format_occurrence_day(day)).to eq('Saturday, May 30')
       end
+
+      context 'when the last occurrence happened yesterday' do
+        let(:day) { Date.yesterday }
+
+        it 'returns Yesterday instead of the date formatted as a string' do
+          expect(ErrorGroupPresenter.format_occurrence_day(day)).to eq('Yesterday')
+        end
+      end
     end
 
     describe '#show_for_day?' do


### PR DESCRIPTION
### Summary

Refactors minor code duplication on error group for last week view, delegating to the presenter the definition of the formatted header.