### PR TITLE
Add support for tracking manual exceptions within transactions

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -20,6 +20,7 @@ detectors:
     enabled: true
     exclude:
       - ExceptionHunter::ErrorCreator
+      - ExceptionHunter::Tracking
     max_copies: 2
     min_clump_size: 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### New features
 
 - [#113](https://github.com/rootstrap/exception_hunter/pull/113) Add configuration to turn on/off async logging using ActionJob. (
-  [@matteo95g][])
+  [@matteo95g][]) 
+- [#119](https://github.com/rootstrap/exception_hunter/pull/119) Add support for tracking manual exceptions within transactions. ([@lalopsb][])
 
 ### Bug fixes
 

--- a/spec/exception_hunter_spec.rb
+++ b/spec/exception_hunter_spec.rb
@@ -67,7 +67,7 @@ module ExceptionHunter
         context 'when the error is tracked within a transaction' do
           before do
             allow(ActiveRecord::Base.connection).to receive(:open_transactions).and_return(1)
-            allow(Thread).to receive(:new).and_yield
+            allow(Thread).to receive(:new).and_call_original
           end
 
           it 'creates a new error within a new thread' do


### PR DESCRIPTION
### Summary

Manual errors tracked on transactions (i.e custom validations) were not tracked.
This happened because whenever the transaction failed, it was rollbacked, and as the error tracking depends on the persisting of a record on the db, that record was also rollbacked along the transaction that contained it.

Now we've included a way of allowing the `ExceptionHunter::Error` to be persisted as a part of a new thread not implicated on the transaction itself, so it (alone, the rest of the transaction will) won't be rollbacked.

This new thread **is only created** if the tracking happens **within** a transaction.

#### Examples:

```
class Payment < ActiveRecord::Base
  validate :is_friend

  belongs_to :friend, class_name: 'User', foreign_key: :friend_id
  belongs_to :sender, class_name: 'User', foreign_key: :sender_id

  private

  def is_friend
    unless (sender.friends.include?(friend))
      errors.add(sender.username, 'you can make payments only to friends.')
      ExceptionHunter.track(ArgumentError.new('Error tracked within transaction'))
    end
  end
end 
```

**Before:**

_The whole transaction is rollbacked and no records have been persisted_

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/5349497/110687677-8b419600-81bf-11eb-860c-cac379a99ced.png">

**Now**:

_Only the outer transaction is rollbacked and the `ExceptionHunter::Error` remains persisted._

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/5349497/110688308-33eff580-81c0-11eb-8377-9b42d31f20f0.png">
