### PR TITLE
Fix #126  update Pagy gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
   remote: .
   specs:
     exception_hunter (1.1.0)
-      pagy (~> 3)
+      pagy (~> 4)
       slack-notifier (~> 2.3)
 
 GEM
@@ -160,7 +160,7 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (3.14.0)
+    pagy (4.11.0)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
@@ -307,4 +307,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   2.1.4
+   2.2.28

--- a/app/views/exception_hunter/errors/pagy/_pagy_nav.html.erb
+++ b/app/views/exception_hunter/errors/pagy/_pagy_nav.html.erb
@@ -1,17 +1,17 @@
 <div class="error-occurrences__nav">
-  <%= link_to pagy_url_for(1, pagy) do %>
-    <%= button_tag 'First', class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.prev.nil? %>
+  <%= link_to pagy_url_for(pagy, 1) do %>
+    <%= button_tag "First", class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.prev.nil? %>
   <% end %>
-  <%= link_to pagy_url_for(pagy.prev, pagy) do %>
-    <%= button_tag '<', class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.prev.nil? %>
+  <%= link_to pagy_url_for(pagy, pagy.prev) do %>
+    <%= button_tag "<", class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.prev.nil? %>
   <% end %>
   <div class="error-occurrences__nav-current">
     <%= occurred_at %> (<%= pagy.page %>/<%= pagy.last %>)
   </div>
-  <%= link_to pagy_url_for(pagy.next, pagy) do %>
-    <%= button_tag '>', class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.next.nil? %>
+  <%= link_to pagy_url_for(pagy, pagy.next) do %>
+    <%= button_tag ">", class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.next.nil? %>
   <% end %>
-  <%= link_to pagy_url_for(pagy.last, pagy) do %>
-    <%= button_tag 'Last', class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.next.nil? %>
+  <%= link_to pagy_url_for(pagy, pagy.last) do %>
+    <%= button_tag "Last", class: %w[button button-outline error-occurrences__nav-link], disabled: pagy.next.nil? %>
   <% end %>
 </div>

--- a/exception_hunter.gemspec
+++ b/exception_hunter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   EXCLUDED_FILES = %w[lib/tasks/code_analysis.rake].freeze
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md'] - EXCLUDED_FILES
 
-  spec.add_dependency 'pagy', '~> 3'
+  spec.add_dependency 'pagy', '~> 4'
   spec.add_dependency 'slack-notifier', '~> 2.3'
 
   spec.add_development_dependency 'brakeman', '~> 4.8'

--- a/lib/exception_hunter/error_creator.rb
+++ b/lib/exception_hunter/error_creator.rb
@@ -36,10 +36,11 @@ module ExceptionHunter
           update_error_group(error_group, error, tag)
           error.error_group = error_group
           error.save!
-          return if error_group.ignored?
 
-          notify(error)
-          error
+          unless error_group.ignored?
+            notify(error)
+            error
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

See #126 

Pagy warnings fixed:

```
[PAGY WARNING] inverted use of pagy/page in pagy_url_for will not be supported in 5.0! Use pagy_url_for(pagy, page) instead.
```

### Other Information

Also fixed ActiveRecord::Base.transaction deprecation warning on using return inside the transaction block:

```
DEPRECATION WARNING: Using `return`, `break` or `throw` to exit a transaction block is
deprecated without replacement. If the `throw` came from
`Timeout.timeout(duration)`, pass an exception class as a second
argument so it doesn't use `throw` to abort its block. This results
in the transaction being committed, but in the next release of Rails
it will rollback.
 (called from create_error at /Users/megatux/code/exception_hunter/lib/exception_hunter/error_creator.rb:31)
```